### PR TITLE
Fix decimal/float multiplication error

### DIFF
--- a/vnpy_longbridge/longbridge_gateway.py
+++ b/vnpy_longbridge/longbridge_gateway.py
@@ -371,7 +371,7 @@ class LongBridgeGateway(BaseGateway):
                     direction=Direction.LONG if stock.quantity >= 0 else Direction.SHORT,
                     price=float(stock.cost_price),
                     frozen=float(stock.quantity - stock.available_quantity),
-                    volume=stock.quantity,
+                    volume=float(stock.quantity),
                     pnl=round(float((quote.last_done - stock.cost_price) * stock.quantity), 2),
                 )
                 position.pct_pnl = round(float(quote.last_done / stock.cost_price - 1) * 100 * sign(stock.quantity), 2)


### PR DESCRIPTION

Convert volume field of PositionData from Decimal to float type to prevent TypeError caused by multiplying float and Decimal types in the update_position_on_tick method. 

This error prevented correct updates of position profit/loss calculations.